### PR TITLE
added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ RUN git clone https://github.com/tbenavi1/genomescope2.0.git \
 # Don't need git, a choice needs to be made about weather to keep gcc/g++ which may concievably be used 
 RUN apk del git
 
-RUN apk cache clean
-
 RUN rm -rf *.tgz *.tar *.zip \
 	&& rm -rf /var/cache/apk/* \
 	&& rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine
+
+LABEL container="genomescope2" \ 
+  about.summary="Reference-free profiling of polyploid genomes " \ 
+  about.home="https://github.com/tbenavi1/genomescope2.0" 
+
+#PREAMBLE
+WORKDIR /home/genomics
+COPY . /home/genomics
+RUN cd /home/genomics
+RUN mkdir -p ~/R_libs/
+
+RUN apk update \
+	&& apk upgrade \
+	&& apk add curl
+
+#MAIN
+ENV R_LIB=/usr/local/lib/R
+ENV R_LIBS_USER=/usr/local/lib/R
+
+RUN mkdir -p /usr/local/lib/R
+
+# Some of these packages will be removed when Genomescope 2 supports R.X.X 
+RUN apk add --no-cache --upgrade cairo make bash curl libressl-dev curl-dev libxml2-dev gcc g++ git coreutils ncurses linux-headers libgit2-dev fontconfig-dev harfbuzz-dev fribidi-dev tiff tiff-dev libxt-dev cairo-dev
+RUN apk add --no-cache --upgrade openjdk11 perl gfortran
+
+# Because genomescope requires the X11 to run, we have to find a way to build a headless install, we use xvfb for that. 
+RUN apk add --no-cache --upgrade xorg-server-dev xorg-server libpng libpng-dev xvfb xvfb-run 
+RUN apk add --no-cache --upgrade libxfont-dev libxfont libfontenc font-xfree86-type1
+RUN apk add --no-cache --upgrade font-adobe-source-code-pro font-adobe-utopia-type1 font-adobe-100dpi font-adobe-75dpi font-adobe-utopia-100dpi font-adobe-utopia-75dpi
+RUN apk add --no-cache --upgrade msttcorefonts-installer fontconfig
+RUN update-ms-fonts
+
+# Note R is installed here, but will is reintalled down to R 3.6.3, this is a cludgey solution
+RUN apk add --no-cache --upgrade R R-dev R-doc
+
+# This section will not be required when Genomescope 2 supports R 4.X.X
+RUN curl -O https://cran.rstudio.com/src/base/R-3/R-3.6.3.tar.gz \
+  && tar -xvf R-3.6.3.tar.gz \
+  && cd R-3.6.3/ \
+  && ./configure --enable-memory-profiling --enable-R-shlib --with-blas --with-lapack --with-x --with-cairo --with-readline=no \
+  && make \
+  && make install \ 
+  && cd ..
+
+RUN Rscript -e 'install.packages("argparse", repos="https://cloud.r-project.org")' \
+  && Rscript -e 'install.packages("minpack.lm", repos="https://cloud.r-project.org")'  
+
+RUN git clone https://github.com/tbenavi1/genomescope2.0.git \
+	&& cd genomescope2.0/ \
+  && cp genomescope.R /usr/bin \
+	&& Rscript -e 'install.packages(".", repos=NULL, type="source", lib="/usr/local/lib/R")'\
+	&& cd .. 
+
+#CLEANUP
+
+# Don't need git, a choice needs to be made about weather to keep gcc/g++ which may concievably be used 
+RUN apk del git
+
+RUN apk cache clean
+
+RUN rm -rf *.tgz *.tar *.zip \
+	&& rm -rf /var/cache/apk/* \
+	&& rm -rf /tmp/*


### PR DESCRIPTION
I created a Dockerfile for a pipeline I'm currently working on that uses Singularity. 

This pull request creates a Dockerfile that when run (say through a github actions pipeline or webhook) in turn creates a docker container. I use this container with Singularity, but there is no reason it shouldn't run with Docker. 

The container build utilizes an Alpine image and tries its best to only add the bare minimum to the image. It also installs in what would be a 'system wide approach' in a non-container setup; this explains why it doesn't use 'install.R' and instead relies on:

```
RUN Rscript -e 'install.packages("argparse", repos="https://cloud.r-project.org")' \
  && Rscript -e 'install.packages("minpack.lm", repos="https://cloud.r-project.org")'  
```

Another quirk is that it currently has a hotfix, genomescope doesn't work with R 4.X.X when I checked yesterday, so it installs R 3.6.3, but this whole section can be removed when genomescope does work with 4.X.X

One last thought, genomescope requires X11, which a headless container wouldn't normally have, to get around this I run genomescope via `xvfb-run` which spoofs X11. That means that when running through singularity the call becomes something like:

```
$ singularity exec dmolik-genomescope2.img xvfb-run  genomescope.R -i 1631574947.histo -o 1631574947 -k 21 --verbose
```

Feel free to check out the container I built from genomescope here:

https://hub.docker.com/repository/docker/dmolik/genomescope2